### PR TITLE
fix(hooks): guard recipe with `command -v echodev` so missing CLI is silent

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Copy these entries into your `.claude/settings.json` (under the top-level `"hook
         "hooks": [
           {
             "type": "command",
-            "command": "test -d .echodev && echodev recall \"$CLAUDE_TOOL_INPUT_file_path\" --quiet --format text || true"
+            "command": "test -d .echodev && command -v echodev >/dev/null 2>&1 && echodev recall \"$CLAUDE_TOOL_INPUT_file_path\" --quiet --format text || true"
           }
         ]
       }
@@ -88,7 +88,7 @@ Copy these entries into your `.claude/settings.json` (under the top-level `"hook
         "hooks": [
           {
             "type": "command",
-            "command": "test -d .echodev && git rev-parse HEAD >/dev/null 2>&1 && echodev extract HEAD --kind commit --llm auto || true"
+            "command": "test -d .echodev && command -v echodev >/dev/null 2>&1 && git rev-parse HEAD >/dev/null 2>&1 && echodev extract HEAD --kind commit --llm auto || true"
           }
         ]
       }
@@ -97,8 +97,10 @@ Copy these entries into your `.claude/settings.json` (under the top-level `"hook
 }
 ```
 
-- `PreToolUse` on `Edit|MultiEdit` → silent recall (gated on `.echodev/` existing)
-- `Stop` → idempotent `extract HEAD`
+- `PreToolUse` on `Edit|MultiEdit` → silent recall (gated on `.echodev/` and `command -v echodev`)
+- `Stop` → idempotent `extract HEAD` (same gates + `git rev-parse HEAD`)
+
+The `command -v echodev` guard keeps the hook silent on machines where the CLI isn't installed yet — teammates can pull the repo before running `npm install -g @hey-echodev/cli` without their Claude Code transcript filling with `echodev: command not found`.
 
 After merging, run `/hooks` inside Claude Code to verify (or restart Claude Code).
 

--- a/packages/cli/integrations/claude-code/hooks/settings.snippet.json
+++ b/packages/cli/integrations/claude-code/hooks/settings.snippet.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "test -d .echodev && echodev recall \"$CLAUDE_TOOL_INPUT_file_path\" --quiet --format text || true"
+            "command": "test -d .echodev && command -v echodev >/dev/null 2>&1 && echodev recall \"$CLAUDE_TOOL_INPUT_file_path\" --quiet --format text || true"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "test -d .echodev && git rev-parse HEAD >/dev/null 2>&1 && echodev extract HEAD --kind commit --llm auto || true"
+            "command": "test -d .echodev && command -v echodev >/dev/null 2>&1 && git rev-parse HEAD >/dev/null 2>&1 && echodev extract HEAD --kind commit --llm auto || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Closes #2. **Stacked on top of #6** — base set to `fix/issue-1-drop-sidecar-print-recipe`. GitHub will auto-retarget to `main` when #6 merges.

On a machine without `@hey-echodev/cli` installed, the PreToolUse hook fired `echodev: command not found` to stderr on every Edit/MultiEdit. The `|| true` masked the exit code but the stderr noise still landed in Claude Code transcripts. Adding `command -v echodev >/dev/null 2>&1` makes the hook silent until the binary is actually on PATH.

Both PreToolUse and Stop entries get the same guard. Order is cheap-first: filesystem check → PATH check → (Stop only) git HEAD check → exec.

## Best-practice alignment

[Claude Code best practices](https://code.claude.com/docs/en/best-practices) — **"Address root causes, not symptoms"**: the root cause is the hook assuming CLI presence, not the stderr noise itself. `command -v` is the POSIX-standard way to test for a binary on PATH (preferred over `which` or `type`).

## Changes

- `packages/cli/integrations/claude-code/hooks/settings.snippet.json` — added `command -v echodev >/dev/null 2>&1 &&` to both commands.
- `README.md` "Hook recipe" section — updated to match; gate-list bullets now mention all three guards (`.echodev/`, `command -v echodev`, `git rev-parse HEAD` for Stop); added a one-line rationale paragraph so future maintainers don't strip the guard as "redundant".

## Test plan

Verified manually:

- [x] **Recipe contains guard** — `echodev init` prints both commands with `command -v echodev >/dev/null 2>&1 &&`
- [x] **Bug reproduced (control)** — without the guard, on a PATH stripped of `echodev`: 39 bytes stderr `sh: line 1: echodev: command not found`
- [x] **Bug fixed (with guard)** — same PATH, with guard: **0 bytes stderr**, exit 0
- [x] **Happy path** — with binary on PATH and a matching decision: hook fires normally, prints recall result on stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)