### PR TITLE
fix(llm): auto-prune bridge artifacts after each successful skill call

### DIFF
--- a/packages/llm/src/SkillBridgeClient.ts
+++ b/packages/llm/src/SkillBridgeClient.ts
@@ -3,6 +3,8 @@ import * as path from "node:path";
 import type { LLMClient, LLMRequest, LLMResponse } from "@hey-echodev/core";
 import { NullLLMClient } from "./NullLLMClient.js";
 
+const DEFAULT_BRIDGE_KEEP = 10;
+
 // Runs inside Claude Code with no API key: prompt → file, skill writes response → file.
 export class SkillBridgeClient implements LLMClient {
   readonly name = "skill-bridge";
@@ -23,6 +25,7 @@ export class SkillBridgeClient implements LLMClient {
     await fs.writeFile(requestFile, JSON.stringify(req, null, 2), "utf8");
     try {
       const text = await this.waitForResponse(responseFile);
+      await pruneBridgeArtifacts(this.bridgeDir);
       return { text };
     } catch (err) {
       if (err instanceof Error && err.message.startsWith("Timed out")) {
@@ -38,5 +41,43 @@ export class SkillBridgeClient implements LLMClient {
 
   didFallback(): boolean {
     return this.fellBack;
+  }
+}
+
+/**
+ * Cap bridge dir size by keeping only the newest `keep` request/response pairs.
+ * Best-effort: any IO error is swallowed so a stale-state directory never blocks
+ * an LLM call. Pairing by stamp prefix prevents orphaned response files when a
+ * matching request gets pruned.
+ */
+export async function pruneBridgeArtifacts(
+  bridgeDir: string,
+  keep = DEFAULT_BRIDGE_KEEP,
+): Promise<void> {
+  try {
+    const entries = await fs.readdir(bridgeDir);
+    const byStamp = new Map<string, string[]>();
+    for (const name of entries) {
+      if (!name.endsWith(".request.json") && !name.endsWith(".response.txt")) continue;
+      const stamp = name.split(".")[0];
+      if (stamp === undefined) continue;
+      const list = byStamp.get(stamp);
+      if (list) list.push(name);
+      else byStamp.set(stamp, [name]);
+    }
+    if (byStamp.size <= keep) return;
+
+    // Stamps are ISO-8601 with `:`/`.` rewritten to `-`; lexical sort = chronological.
+    const stamps = [...byStamp.keys()].sort();
+    const drop = stamps.slice(0, stamps.length - keep);
+    await Promise.all(
+      drop.flatMap((stamp) =>
+        (byStamp.get(stamp) ?? []).map((name) =>
+          fs.unlink(path.join(bridgeDir, name)).catch(() => undefined),
+        ),
+      ),
+    );
+  } catch {
+    // Pruning is best-effort.
   }
 }


### PR DESCRIPTION
## Summary

Closes #3. Independent of #6/#7 — branched off `main`, no overlap with the init/snippet PRs.

`.echodev/bridge/` accumulates one request + one response file per skill-bridge LLM call. With no lifecycle in place, the directory grows unbounded — one production user reported 70+ files after ~1 month. Their workaround was a Stop hook calling `ls -t … | tail -n +11 | xargs rm -f`. This PR moves that lifecycle inside the bridge client itself, keyed on the same `keep=10` value.

## Best-practice alignment

Two anchors:

- [Claude Code best practices](https://code.claude.com/docs/en/best-practices) **"Address root causes, not symptoms"** — the root cause is that `.echodev/bridge/` has no lifecycle. The fix attaches lifecycle inside the class that creates the files (`SkillBridgeClient`), not at an outer boundary (e.g. extract command termination or a separate `prune` subcommand).
- README thesis #3 **"Prefer silence over noise"** — pruning is best-effort and silent. Any IO error is swallowed so it never blocks an LLM call. No flag, no logging, no env var (YAGNI; if a user wants different retention they can edit their own Stop hook, which is what the reporter already did).

## Design notes

- **Keep 10**: matches the reporting user's own workaround. No flag introduced.
- **Pair by stamp prefix**: each call writes `<stamp>.request.json` and `<stamp>.response.txt`. Pruning by stamp drops both together; orphan response files (e.g. when an old request was already pruned but its response slipped in) are picked up too.
- **Lexical sort = chronological**: stamps are ISO-8601 with `:`/`.` rewritten to `-`, so a plain string sort gives chronological order without parsing.
- **Where it runs**: at the end of the success path inside `complete()`, after `waitForResponse` resolves. Not on the timeout/fallback path — keep failed requests around for debugging.

## Changes

- `packages/llm/src/SkillBridgeClient.ts` — new exported `pruneBridgeArtifacts(dir, keep=10)`; call it from `complete()` after successful response.

## Test plan

Verified via standalone Node script (4 scenarios, all pass):

- [x] **A — standalone prune**: 15 stamps × 2 files (30 files) → after prune: 20 files / 10 stamps; oldest dropped, newest kept
- [x] **B — end-to-end**: 12 sequential `complete()` calls with a fake `waitForResponse` → bridge dir caps at 10 stamps automatically
- [x] **C — no-op when ≤ keep**: 5 stamps with `keep=10` → no files removed
- [x] **D — orphan response handled**: 11 request files + 1 isolated old response → all 10 oldest stamps pruned (request + orphan response together)

End-to-end verification with a real Claude Code skill bridge requires a live Claude Code session; not feasible in CI. The standalone tests cover the prune logic; the integration into `complete()` is a single call after a successful path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)