### PR TITLE
fix(recall): switch hook contract from undocumented env var to stdin JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Copy these entries into your `.claude/settings.json` (under the top-level `"hook
         "hooks": [
           {
             "type": "command",
-            "command": "test -d .echodev && command -v echodev >/dev/null 2>&1 && echodev recall \"$CLAUDE_TOOL_INPUT_file_path\" --quiet --format text || true"
+            "command": "test -d .echodev && command -v echodev >/dev/null 2>&1 && echodev recall --from-stdin --quiet --format text || true"
           }
         ]
       }
@@ -100,7 +100,11 @@ Copy these entries into your `.claude/settings.json` (under the top-level `"hook
 - `PreToolUse` on `Edit|MultiEdit` → silent recall (gated on `.echodev/` and `command -v echodev`)
 - `Stop` → idempotent `extract HEAD` (same gates + `git rev-parse HEAD`)
 
-The `command -v echodev` guard keeps the hook silent on machines where the CLI isn't installed yet — teammates can pull the repo before running `npm install -g @hey-echodev/cli` without their Claude Code transcript filling with `echodev: command not found`.
+#### Hook contract
+
+PreToolUse consumes Claude Code's [documented hook input](https://code.claude.com/docs/en/hooks-guide) — a JSON object on stdin with a `tool_input.file_path` field. `recall --from-stdin` parses it; the contract surface lives inside this CLI so the recipe stays POSIX-pure (no `jq` dependency) and so a future Claude Code schema change needs one fix here, not in every consumer's `settings.json`. The `command -v echodev` guard keeps the hook silent on machines where the CLI isn't installed.
+
+**Tested against Claude Code as of 2026-04.** If the hook stops returning recall results after a Claude Code update, the contract may have shifted — open an issue or check `recall --from-stdin` against the latest [hooks reference](https://code.claude.com/docs/en/hooks).
 
 After merging, run `/hooks` inside Claude Code to verify (or restart Claude Code).
 

--- a/packages/cli/integrations/claude-code/hooks/settings.snippet.json
+++ b/packages/cli/integrations/claude-code/hooks/settings.snippet.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "test -d .echodev && command -v echodev >/dev/null 2>&1 && echodev recall \"$CLAUDE_TOOL_INPUT_file_path\" --quiet --format text || true"
+            "command": "test -d .echodev && command -v echodev >/dev/null 2>&1 && echodev recall --from-stdin --quiet --format text || true"
           }
         ]
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import { check } from "./commands/check.js";
 import { list } from "./commands/list.js";
 import { graph } from "./commands/graph.js";
 import { add } from "./commands/add.js";
+import { readStdin } from "./util/io.js";
 import { DEFAULT_MIN_SCORE, DEFAULT_TOP_K, isDecisionStatus } from "@hey-echodev/core";
 
 const USAGE = `echodev — persistent design memory for Claude-assisted codebases
@@ -18,9 +19,9 @@ Usage:
   echodev init [--no-claude]
   echodev uninstall [--no-claude] [--purge]
   echodev migrate
-  echodev recall <paths...> [--modules a,b] [--keywords x,y]
-                            [--top K] [--min-score N] [--quiet] [--explain]
-                            [--if-expired-block] [--format json|text]
+  echodev recall [<paths...>] [--from-stdin] [--modules a,b] [--keywords x,y]
+                              [--top K] [--min-score N] [--quiet] [--explain]
+                              [--if-expired-block] [--format json|text]
   echodev extract <ref> [--kind commit|diff|pr|manual] [--llm auto|api|skill|null] [--force]
                         [--skill-timeout <seconds>]
   echodev add --stdin [--ref <label>]
@@ -90,8 +91,9 @@ async function main(): Promise<void> {
       return;
     }
     case "recall": {
+      const stdinPaths = flagBool(args, "from-stdin") ? await readPathsFromHookStdin() : [];
       const { text } = await recall(wire({ repoRoot }), {
-        files: args.positionals,
+        files: [...stdinPaths, ...args.positionals],
         modules: splitCsv(flagString(args, "modules")),
         keywords: splitCsv(flagString(args, "keywords")),
         format: (flagString(args, "format") ?? "text") as "json" | "text",
@@ -182,6 +184,23 @@ function numFlag(args: ParsedArgs, key: string, fallback: number): number {
   const n = Number(raw);
   if (!Number.isFinite(n)) throw new Error(`--${key} must be a number, got "${raw}"`);
   return n;
+}
+
+// Reads Claude Code's documented hook input — JSON on stdin with a
+// `tool_input.file_path` field (see https://code.claude.com/docs/en/hooks-guide).
+// Stays silent on missing/invalid input so a contract drift becomes a no-op
+// rather than a crash; the user notices via empty recall output.
+async function readPathsFromHookStdin(): Promise<readonly string[]> {
+  if (process.stdin.isTTY) return [];
+  try {
+    const raw = await readStdin();
+    if (raw.trim().length === 0) return [];
+    const parsed = JSON.parse(raw) as { tool_input?: { file_path?: unknown } };
+    const fp = parsed.tool_input?.file_path;
+    return typeof fp === "string" && fp.length > 0 ? [fp] : [];
+  } catch {
+    return [];
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Closes #4. **Stacked on #7** (which is stacked on #6) — base set to `fix/issue-2-command-v-guard`. GitHub will retarget as the underlying PRs merge.

The reporter flagged `\$CLAUDE_TOOL_INPUT_file_path` as an "undocumented internal contract". Verified: it's nowhere in the [official hooks guide](https://code.claude.com/docs/en/hooks-guide). The documented contract is JSON on stdin with a `tool_input.file_path` field — every example in the doc uses `jq -r '.tool_input.file_path'`. So the issue's concern was stronger than written: we weren't just *coupled* to an internal, we were **using something that isn't a public API at all**.

This PR switches to the documented contract. Pure docs would explain the breakage but not fix it.

## Best-practice alignment

- [Claude Code best practices](https://code.claude.com/docs/en/best-practices) **"Address root causes, not symptoms"** — root cause was reliance on an undocumented env var. Fix: consume the documented stdin-JSON contract.
- User directive **"locked on Claude Code design, don't add maintenance cost"** — pulling parsing into our CLI (vs `jq` in the hook string) means future schema changes need one update here, not in every consumer's `settings.json`. The recipe stays POSIX-pure.
- README thesis **#3 "Prefer silence over noise"** — `--from-stdin` swallows empty/invalid/missing-field inputs into a silent no-op. A contract drift becomes "no recall results" (visible to the user) rather than a crash or stderr noise.

## Changes

- `packages/cli/src/index.ts` — new `recall --from-stdin` flag; reads stdin if not a TTY, parses JSON, extracts `tool_input.file_path`, prepends to positionals. Skip-on-error (silent) so empty/invalid input is harmless. USAGE updated.
- `packages/cli/integrations/claude-code/hooks/settings.snippet.json` — PreToolUse command swapped from `"\$CLAUDE_TOOL_INPUT_file_path"` to `--from-stdin`.
- `README.md` — Hook recipe updated; new "Hook contract" subsection explains the documented stdin-JSON contract and includes a **"Tested against Claude Code as of 2026-04"** line so freshness is visible.

## Out of scope (follow-up)

`packages/cli/src/commands/recall.ts:113-119` still reads three other undocumented env vars (`CLAUDE_TOOL_INPUT_new_string` / `_new_content` / `_content`) for the `--if-expired-block` feature. Same root issue, same fix pattern (read from the parsed JSON). Splitting to keep this PR focused on the issue's stated concern (`file_path`).

## Backward compatibility

Users on the old env-var-based hook recipe keep working as long as Claude Code still emits the env var. The new recipe is opt-in via re-running `echodev init` and re-pasting. No silent breakage on upgrade.

## Test plan

Manually verified 7 scenarios in a sandbox repo with one matching decision:

- [x] **A — happy path**: full Claude-Code-shaped JSON with `tool_input.file_path` → recall returns matched decision
- [x] **B — empty stdin** → silent (exit 0, 0 bytes stderr)
- [x] **C — invalid JSON** → silent
- [x] **D — JSON without `tool_input.file_path`** → silent
- [x] **E — empty `file_path` string** → silent
- [x] **F — mixed positional + `--from-stdin`**: pre-existing greedy-flag-parser quirk consumes `--from-stdin <next>` as a string flag; rearranging works (`recall <pos> --from-stdin`). Real hook usage has no positionals so unaffected. Parser fix is out of scope.
- [x] **G — init recipe** prints the new `--from-stdin` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)