### PR TITLE
fix(args): keep boolean flags from greedily consuming next positional

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -4,6 +4,22 @@ export interface ParsedArgs {
   readonly flags: ReadonlyMap<string, string | boolean>;
 }
 
+// Flags that never take a value. Listed here so the parser doesn't greedily
+// consume the next positional as their "value" — e.g. `recall --from-stdin
+// "src/foo.ts"` must parse as `{from-stdin: true, positional: "src/foo.ts"}`,
+// not `{from-stdin: "src/foo.ts"}`.
+const BOOL_FLAGS: ReadonlySet<string> = new Set([
+  "help",
+  "no-claude",
+  "purge",
+  "force",
+  "stdin",
+  "from-stdin",
+  "quiet",
+  "explain",
+  "if-expired-block",
+]);
+
 export function parseArgs(argv: readonly string[]): ParsedArgs {
   const positionals: string[] = [];
   const flags = new Map<string, string | boolean>();
@@ -13,14 +29,19 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
       const eq = token.indexOf("=");
       if (eq !== -1) {
         flags.set(token.slice(2, eq), token.slice(eq + 1));
+        continue;
+      }
+      const name = token.slice(2);
+      if (BOOL_FLAGS.has(name)) {
+        flags.set(name, true);
+        continue;
+      }
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags.set(name, next);
+        i += 1;
       } else {
-        const next = argv[i + 1];
-        if (next !== undefined && !next.startsWith("--")) {
-          flags.set(token.slice(2), next);
-          i += 1;
-        } else {
-          flags.set(token.slice(2), true);
-        }
+        flags.set(name, true);
       }
     } else {
       positionals.push(token);


### PR DESCRIPTION
## Summary

Closes #11. Previously discovered in PR #9 verification scenario F.

`parseArgs` greedily set the next non-`--` token as a flag's value, hijacking positionals after boolean flags. Real hook usage escaped this (the hook string `recall --from-stdin --quiet --format text` doesn't mix positionals after boolean flags), but it's a surprise for humans and future contributors.

Adds a `BOOL_FLAGS` allowlist (`help`, `no-claude`, `purge`, `force`, `stdin`, `from-stdin`, `quiet`, `explain`, `if-expired-block`) — for those the parser sets `true` and never consumes the next token. Value-taking flags are unchanged.

## Test plan

Verified manually with `--from-stdin` + positional and 4 regression scenarios:

- [x] `recall --from-stdin "src/bar.ts" --quiet` → both stdin's `tool_input.file_path` and `"src/bar.ts"` searched (the original bug)
- [x] `recall "src/foo.ts" --top 3` → numeric flag value still works
- [x] `recall --from-stdin --quiet --format text` (real hook shape) → unchanged
- [x] `recall "src/foo.ts" --quiet --format text` → bool + string flags adjacent
- [x] `init --no-claude` → boolean flag on init, no `.claude/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)