### PR TITLE
fix(recall): drop remaining undocumented CLAUDE_TOOL_INPUT_* env vars

### DIFF
--- a/packages/cli/src/commands/recall.ts
+++ b/packages/cli/src/commands/recall.ts
@@ -13,11 +13,19 @@ export interface RecallOptions {
   /** When true, dump per-candidate score breakdown for debugging. */
   readonly explain: boolean;
   /**
-   * When true and the PreToolUse env carries the edit's new content, emit a
-   * Claude Code block JSON decision if any matching decision's expiry
-   * condition is tripped. Off by default (advisory mode).
+   * When true and `editNewContent` is supplied, emit a Claude Code block JSON
+   * decision if any matching decision's expiry condition is tripped. Off by
+   * default (advisory mode).
    */
   readonly ifExpiredBlock: boolean;
+  /**
+   * The pending edit's "after" content, sourced from Claude Code's hook
+   * stdin JSON (`tool_input.new_string` for Edit, `tool_input.content` for
+   * Write, joined `tool_input.edits[].new_string` for MultiEdit). Required
+   * for `--if-expired-block` to detect tripped expiry conditions; left
+   * undefined otherwise.
+   */
+  readonly editNewContent?: string;
 }
 
 export interface RecallOutput {
@@ -35,7 +43,7 @@ export async function recall(services: Services, opts: RecallOptions): Promise<R
   const result = await recallDecisions(services.repo, services.retriever, opts);
 
   if (opts.ifExpiredBlock) {
-    const blocked = detectExpiredBlock(result.hits);
+    const blocked = detectExpiredBlock(result.hits, opts.editNewContent);
     if (blocked !== undefined) {
       return { text: JSON.stringify(blocked), hitCount: result.hits.length };
     }
@@ -89,11 +97,11 @@ async function explainMode(services: Services, opts: RecallOptions): Promise<Rec
 
 function detectExpiredBlock(
   hits: readonly RetrievalHit[],
+  editNewContent: string | undefined,
 ): { decision: "block"; reason: string } | undefined {
-  const content = readEditNewContent();
-  if (content === undefined || content.length === 0) return undefined;
+  if (editNewContent === undefined || editNewContent.length === 0) return undefined;
 
-  const lines = content.split(/\r?\n/);
+  const lines = editNewContent.split(/\r?\n/);
   for (const hit of hits) {
     for (const expiry of hit.node.expiry_conditions) {
       const tripped = lines.some((line) => lineMatchesExpiry(line, expiry));
@@ -108,14 +116,6 @@ function detectExpiredBlock(
     }
   }
   return undefined;
-}
-
-function readEditNewContent(): string | undefined {
-  return (
-    process.env["CLAUDE_TOOL_INPUT_new_string"] ??
-    process.env["CLAUDE_TOOL_INPUT_new_content"] ??
-    process.env["CLAUDE_TOOL_INPUT_content"]
-  );
 }
 
 function formatCandidate(c: ExplainedHit): readonly string[] {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -91,9 +91,9 @@ async function main(): Promise<void> {
       return;
     }
     case "recall": {
-      const stdinPaths = flagBool(args, "from-stdin") ? await readPathsFromHookStdin() : [];
+      const hookInput = flagBool(args, "from-stdin") ? await readHookStdin() : undefined;
       const { text } = await recall(wire({ repoRoot }), {
-        files: [...stdinPaths, ...args.positionals],
+        files: [...(hookInput?.paths ?? []), ...args.positionals],
         modules: splitCsv(flagString(args, "modules")),
         keywords: splitCsv(flagString(args, "keywords")),
         format: (flagString(args, "format") ?? "text") as "json" | "text",
@@ -102,6 +102,7 @@ async function main(): Promise<void> {
         quiet: flagBool(args, "quiet"),
         explain: flagBool(args, "explain"),
         ifExpiredBlock: flagBool(args, "if-expired-block"),
+        editNewContent: hookInput?.editNewContent,
       });
       if (text.length > 0) process.stdout.write(`${text}\n`);
       return;
@@ -186,20 +187,55 @@ function numFlag(args: ParsedArgs, key: string, fallback: number): number {
   return n;
 }
 
-// Reads Claude Code's documented hook input — JSON on stdin with a
-// `tool_input.file_path` field (see https://code.claude.com/docs/en/hooks-guide).
-// Stays silent on missing/invalid input so a contract drift becomes a no-op
-// rather than a crash; the user notices via empty recall output.
-async function readPathsFromHookStdin(): Promise<readonly string[]> {
-  if (process.stdin.isTTY) return [];
+interface HookStdin {
+  readonly paths: readonly string[];
+  readonly editNewContent?: string;
+}
+
+// Reads Claude Code's documented hook input — JSON on stdin with a `tool_input`
+// object (see https://code.claude.com/docs/en/hooks-guide). Extracts both the
+// file path (Edit/MultiEdit/Write) and the new content for `--if-expired-block`.
+// MultiEdit's `tool_input.edits[]` is concatenated. Stays silent on
+// missing/invalid input so contract drift becomes a no-op rather than a crash.
+async function readHookStdin(): Promise<HookStdin | undefined> {
+  if (process.stdin.isTTY) return undefined;
   try {
     const raw = await readStdin();
-    if (raw.trim().length === 0) return [];
-    const parsed = JSON.parse(raw) as { tool_input?: { file_path?: unknown } };
-    const fp = parsed.tool_input?.file_path;
-    return typeof fp === "string" && fp.length > 0 ? [fp] : [];
+    if (raw.trim().length === 0) return undefined;
+    const parsed = JSON.parse(raw) as {
+      tool_input?: {
+        file_path?: unknown;
+        new_string?: unknown;
+        content?: unknown;
+        edits?: unknown;
+      };
+    };
+    const ti = parsed.tool_input;
+    if (ti === undefined || ti === null) return undefined;
+
+    const fp = typeof ti.file_path === "string" && ti.file_path.length > 0 ? ti.file_path : undefined;
+
+    let editNewContent: string | undefined;
+    if (typeof ti.new_string === "string" && ti.new_string.length > 0) {
+      editNewContent = ti.new_string;
+    } else if (typeof ti.content === "string" && ti.content.length > 0) {
+      // Write tool ships full file body as `content`.
+      editNewContent = ti.content;
+    } else if (Array.isArray(ti.edits)) {
+      const joined = ti.edits
+        .map((e) => {
+          if (e === null || typeof e !== "object") return "";
+          const ns = (e as { new_string?: unknown }).new_string;
+          return typeof ns === "string" ? ns : "";
+        })
+        .filter((s) => s.length > 0)
+        .join("\n");
+      if (joined.length > 0) editNewContent = joined;
+    }
+
+    return { paths: fp !== undefined ? [fp] : [], editNewContent };
   } catch {
-    return [];
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #10. Follow-up to #4 / PR #9.

PR #9 switched `recall`'s path argument from `\$CLAUDE_TOOL_INPUT_file_path` to the documented stdin-JSON contract (`tool_input.file_path`). The `--if-expired-block` feature still read three other undocumented env vars (`CLAUDE_TOOL_INPUT_new_string` / `_new_content` / `_content`). Same root cause — undocumented Claude Code internal contract — same fix: extract from the same parsed JSON.

## Changes

- `packages/cli/src/index.ts`
  - `readPathsFromHookStdin` → `readHookStdin`; returns `{paths, editNewContent}`.
  - Handles three Claude Code event shapes: Edit's `tool_input.new_string`, Write's `tool_input.content`, MultiEdit's `tool_input.edits[].new_string` (joined).
  - Wires `editNewContent` into the `recall` call.
- `packages/cli/src/commands/recall.ts`
  - `RecallOptions` gains `editNewContent?: string`.
  - `detectExpiredBlock` accepts it as a parameter instead of reading `process.env`.
  - `readEditNewContent()` deleted.

After this PR, **no `CLAUDE_TOOL_INPUT_*` env var is read anywhere in the codebase.**

## Test plan

Verified manually with a sandbox decision having `expiry_conditions: ["uses localStorage for tokens"]`:

- [x] **A — Edit `new_string` trips block** — `{"tool_input":{"new_string":"localStorage.setItem(\"tokens\", x)"}}` → block JSON returned
- [x] **B — MultiEdit `edits[]` joined trips** — multi-edit shape with one edit containing the trip pattern → block JSON
- [x] **C — Write `content` trips** — `{"tool_input":{"content":"... localStorage ... tokens ..."}}` → block JSON
- [x] **D — env vars NO longer read (root cause confirmed)** — `CLAUDE_TOOL_INPUT_new_string=...trip...` set, but no `--from-stdin` → just decision, no block (proves env var dependency is gone)
- [x] **E — `--if-expired-block` without trip** — normal `new_string` content → just hits, no block

🤖 Generated with [Claude Code](https://claude.com/claude-code)