### PR TITLE
fix(migrate): refactor to forward-migration chain + document policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Each decision is one JSON file under `.echodev/decisions/<id>.json`:
 
 ```jsonc
 {
+  "schema_version":   "1.0",
   "id":               "d-YYYY-MM-DD-<slug>",
   "status":           "active | superseded | expired",
   "problem":          "...", "decision": "...",
@@ -162,6 +163,16 @@ Each decision is one JSON file under `.echodev/decisions/<id>.json`:
 ```
 
 Full schema: [`schema/decision.schema.json`](https://github.com/jieyao-MilestoneHub/EchoDev/blob/main/schema/decision.schema.json) — language-agnostic, any tool can read/write.
+
+### Schema versioning
+
+Every decision file carries `schema_version`. The current version is `"1.0"`.
+
+- **Writers stamp it.** `echodev add` and `echodev extract` set `schema_version: "1.0"` on every decision they produce.
+- **Readers fail-closed.** Any decision missing `schema_version`, or carrying a value the running CLI doesn't know, is rejected with an error pointing to `echodev migrate`. This prevents silent corruption when the schema evolves.
+- **`echodev migrate` walks a forward chain.** `packages/cli/src/commands/migrate.ts` declares a `MIGRATIONS` registry — currently one step (`undefined → "1.0"`, backfilling pre-versioned legacy files). The walker applies whatever steps lead from the file's current version to the target.
+- **Adding v2 is one append.** When a future schema change ships, add a `{from: "1.0", to: "1.1", apply: ...}` entry to the chain. `echodev migrate` picks it up; existing files migrate forward in a single pass; no other code changes.
+- **No downgrade.** A file carrying a version newer than the running CLI knows about has no chain step → migrate refuses with a clear error rather than corrupting it. Upgrade the CLI instead.
 
 ### What to commit
 

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -13,6 +13,28 @@ export interface MigrateResult {
   readonly failed: readonly { file: string; error: string }[];
 }
 
+interface Migration {
+  /** Source version. `undefined` matches pre-versioned legacy files. */
+  readonly from: string | undefined;
+  /** Target version after this step. */
+  readonly to: string;
+  /** Pure transform — must produce an object with `schema_version === to`. */
+  readonly apply: (raw: Record<string, unknown>) => Record<string, unknown>;
+}
+
+// Forward-only migration chain. Future v1.1 / v2 append a one-line entry
+// here; the walker picks them up automatically. Each step's `to` must equal
+// the produced object's `schema_version` (asserted at runtime).
+const MIGRATIONS: readonly Migration[] = [
+  {
+    from: undefined,
+    to: "1.0",
+    apply: (raw) => ({ schema_version: "1.0", ...raw }),
+  },
+];
+
+const MAX_CHAIN_DEPTH = 32;
+
 export async function migrate(opts: MigrateOptions): Promise<MigrateResult> {
   const decisionsDir = path.join(opts.repoRoot, ".echodev", "decisions");
   const entries = await safeReadDir(decisionsDir);
@@ -25,25 +47,17 @@ export async function migrate(opts: MigrateOptions): Promise<MigrateResult> {
     if (!name.endsWith(".json")) continue;
     const file = path.join(decisionsDir, name);
     try {
-      const raw = JSON.parse(await fs.readFile(file, "utf8")) as Record<string, unknown>;
-      if (raw === null || typeof raw !== "object") {
+      const raw = JSON.parse(await fs.readFile(file, "utf8")) as unknown;
+      if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
         failed.push({ file: name, error: "not a JSON object" });
         continue;
       }
-      const current = raw["schema_version"];
-      if (current === CURRENT_SCHEMA_VERSION) {
+      const result = migrateForward(raw as Record<string, unknown>, CURRENT_SCHEMA_VERSION);
+      if (!result.changed) {
         skipped.push(name);
         continue;
       }
-      if (current !== undefined && current !== CURRENT_SCHEMA_VERSION) {
-        failed.push({
-          file: name,
-          error: `schema_version "${String(current)}" is not "${CURRENT_SCHEMA_VERSION}"; refusing to downgrade`,
-        });
-        continue;
-      }
-      const next = { schema_version: CURRENT_SCHEMA_VERSION, ...raw };
-      await atomicWriteJson(file, next);
+      await atomicWriteJson(file, result.value);
       migrated.push(name);
     } catch (err) {
       failed.push({ file: name, error: err instanceof Error ? err.message : String(err) });
@@ -51,6 +65,42 @@ export async function migrate(opts: MigrateOptions): Promise<MigrateResult> {
   }
 
   return { migrated, skipped, failed };
+}
+
+interface MigrateForwardResult {
+  readonly value: Record<string, unknown>;
+  readonly changed: boolean;
+}
+
+// Walks the chain: at each step, find the migration whose `from` matches the
+// current `schema_version` (or undefined for pre-versioned files), apply it,
+// repeat until we reach `target`. Throws on (a) unknown current version with
+// no matching step (covers both unknown legacy and future-version downgrade
+// attempts), or (b) a buggy step that fails to advance the version.
+export function migrateForward(
+  raw: Record<string, unknown>,
+  target: string,
+): MigrateForwardResult {
+  let value = raw;
+  let changed = false;
+  for (let i = 0; i < MAX_CHAIN_DEPTH; i += 1) {
+    const current = value["schema_version"];
+    if (current === target) return { value, changed };
+    const step = MIGRATIONS.find((m) => m.from === current);
+    if (step === undefined) {
+      throw new Error(
+        `no migration path from schema_version "${String(current)}" to "${target}"`,
+      );
+    }
+    value = step.apply(value);
+    if (value["schema_version"] !== step.to) {
+      throw new Error(
+        `migration ${String(step.from)}→${step.to} did not set schema_version correctly`,
+      );
+    }
+    changed = true;
+  }
+  throw new Error(`migration chain exceeded ${MAX_CHAIN_DEPTH} steps; possible cycle`);
 }
 
 async function safeReadDir(dir: string): Promise<readonly string[]> {


### PR DESCRIPTION
## Summary

Closes #12. Closes #5.

Issue #5 reporter asked for a documented migration policy "so v2 doesn't require a breaking script". The `schema_version` mechanism was already shipped in v0.2.0 (writers stamp, readers fail-closed, `migrate` backfills missing → "1.0"), but `migrate.ts` was a single-step procedure that would need restructuring to handle a v2 — exactly the situation the reporter wanted to avoid.

This PR refactors to a chain-of-migrations pattern + adds the policy to README.

## Changes

### `packages/cli/src/commands/migrate.ts`

- New `MIGRATIONS: readonly Migration[]` registry. One entry today: `{from: undefined, to: "1.0", apply: ...}` (legacy backfill).
- New exported `migrateForward(raw, target)` walks the chain step-by-step until the file's `schema_version` matches `target`.
- Guards: each step must advance `schema_version` to its declared `to`; total walk ≤ 32 steps (cycle protection).
- "Refuse to downgrade" semantic preserved — unknown future versions have no `from` match → walker throws with clear message.

Adding v2 in the future is a one-liner:

```ts
const MIGRATIONS = [
  { from: undefined, to: "1.0", apply: (r) => ({ schema_version: "1.0", ...r }) },
  { from: "1.0", to: "1.1", apply: (r) => ({ ...r, schema_version: "1.1", new_field: defaultValue }) },
  // ...
];
```

### `README.md`

- `"schema_version": "1.0"` added to the "Decision schema" JSON example (previously missing — visual mismatch with the actual schema).
- New "Schema versioning" subsection covering: writers stamp, readers fail-closed, `migrate` walks the chain, adding v2 = one append, no downgrade.

## Test plan

Manually verified with a sandbox `.echodev/decisions/` containing three files (legacy / current / "future" / invalid):

- [x] **A — first migrate run**: legacy → backfilled to `"1.0"`; current → skipped; `"9.9"` future → failed with `no migration path from schema_version "9.9" to "1.0"`
- [x] **B — schema_version at top of file** (spread order: `{schema_version, ...raw}`)
- [x] **C — idempotent re-run**: 0 migrated, all current files skipped
- [x] **D — invalid JSON file**: failed with parse error; exit 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)