### PR TITLE
release(cli): 0.3.0 — best-practices audit follow-up batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,171 @@ All notable changes to `@hey-echodev/cli` are documented here. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project follows [SemVer](https://semver.org/).
 
+## [0.3.0] - 2026-04-26
+
+Best-practices audit follow-up batch. A production user reported five
+concerns after a month of integrated use; investigation surfaced five more
+follow-up gaps. Closes 10 issues across 9 PRs (#1-#5 reported, #10-#13 +
+#18 follow-up). Every change is anchored in [Claude Code's official best
+practices](https://code.claude.com/docs/en/best-practices) and the project's
+"prefer silence over noise" thesis — see `docs/best_practice.md` (new) for
+the consolidated reasoning.
+
+### Fixed (P0 — installation hygiene)
+
+- **No more sidecar file in `.claude/`.** `echodev init` no longer writes
+  `.claude/echodev.hooks.snippet.json`. The Claude Code best-practices guide
+  is explicit that `.claude/settings.json` is the user's file ("Edit
+  `.claude/settings.json` directly to configure hooks by hand"). EchoDev now
+  prints the hook recipe to stdout for the user to paste; the recipe also
+  lives in README's "Hook recipe" section. `init` detects an existing
+  `echodev recall` entry and skips printing on re-run. `uninstall` keeps the
+  one-line cleanup for legacy sidecars from prior versions. (#1)
+- **Hook recipe stays silent on machines without the CLI.** Both PreToolUse
+  and Stop hooks now wrap their `echodev` call with
+  `command -v echodev >/dev/null 2>&1` so a teammate cloning the repo before
+  `npm install -g`'ing the CLI no longer fills their Claude Code transcript
+  with `echodev: command not found` stderr. (#2)
+- **args parser no longer hijacks positionals after boolean flags.** A
+  pre-existing greedy-lookahead in `parseArgs` consumed the next non-`--`
+  token as a value for any flag, so `recall --from-stdin "src/foo.ts"`
+  parsed as `{from-stdin: "src/foo.ts"}` instead of
+  `{from-stdin: true, positional: "src/foo.ts"}`. Fixed by allowlisting
+  known boolean flags. (#11)
+
+### Fixed (P0 — hook contract robustness)
+
+- **PreToolUse contract switched to documented stdin JSON.** The old recipe
+  read `$CLAUDE_TOOL_INPUT_file_path` — an undocumented Claude Code
+  internal that doesn't appear in the
+  [hooks guide](https://code.claude.com/docs/en/hooks-guide). The
+  documented contract is JSON on stdin (every official example uses
+  `jq -r '.tool_input.file_path'`). New `echodev recall --from-stdin` flag
+  parses the documented JSON; the contract surface lives inside this CLI so
+  a future Claude Code schema change needs one fix here, not in every
+  consumer's `settings.json`. README adds a "Hook contract" subsection and
+  a "Tested against Claude Code as of 2026-04" line so freshness is
+  visible. (#4, #10)
+- **`--if-expired-block` no longer reads any undocumented env var.** The
+  feature previously read `CLAUDE_TOOL_INPUT_new_string` /
+  `_new_content` / `_content`. All three are now sourced from the same
+  parsed stdin JSON: `tool_input.new_string` for Edit, `tool_input.content`
+  for Write, joined `tool_input.edits[].new_string` for MultiEdit. With
+  this, no `CLAUDE_TOOL_INPUT_*` env var is read anywhere in the
+  codebase. (#10)
+
+### Added — user-facing improvements
+
+- **Bridge artifacts auto-prune on every successful skill call.**
+  `.echodev/bridge/` was growing unbounded — one production user reported
+  70+ files after a month. The class that creates the files
+  (`SkillBridgeClient`) now keeps the newest 10 stamps (paired
+  request+response) on each successful `complete()`. Best-effort: any IO
+  error is swallowed so a stale-state directory never blocks an LLM
+  call. (#3)
+- **`echodev recall --from-stdin`** — see "hook contract" above. The flag
+  is the migration path for hooks coming off the old env-var contract.
+- **`echodev migrate` is now a forward-migration chain.** The previous
+  single-step procedure (`undefined → "1.0"`) would have forced a rewrite
+  to handle a v2; now a `MIGRATIONS: Migration[]` registry walked by
+  `migrateForward` makes adding v2 a one-line append. The "refuse to
+  downgrade" semantic survives — unknown future versions have no chain
+  step and throw with a clear message. README's "Decision schema" example
+  now includes `"schema_version": "1.0"` (was missing) and a new "Schema
+  versioning" subsection documents the policy. (#5, #12)
+- **`docs/best_practice.md`** — new user-facing best-practices guide. 8
+  sections covering when EchoDev helps, setup order, writing good
+  decisions, hook discipline, recall posture, schema discipline, CLAUDE.md
+  integration, and anti-patterns. Every rule cites both a Claude Code
+  anchor and an EchoDev design anchor; the introduction states this
+  constraint so future additions stay disciplined. README's "Claude Code
+  integration" section gains a one-line pointer. (#18)
+
+### Internal — testability
+
+- **Vitest setup + 42 regression tests.** Previous releases verified
+  manually because there was no test runner. This release introduces
+  `vitest` (root devDep, single root `vitest.config.ts` aliasing
+  `@hey-echodev/*` to source so tests skip the build step) and converts
+  the manual scenarios from the recent PRs into vitest suites:
+  `args.test.ts` (boolean flag handling), `migrate.test.ts` (chain
+  walker + filesystem migrate), `init.test.ts` (recipe contents +
+  side-effect assertions), `SkillBridgeClient.test.ts`
+  (`pruneBridgeArtifacts` + end-to-end). `tsconfig.base.json` excludes
+  `**/*.test.ts` from the production build. (#13)
+
+### Upgrading from 0.2.0
+
+**Direct upgrade is safe.** The new CLI binary works against your existing
+decisions, hooks, and `.claude/settings.json` without forced changes:
+
+```bash
+npm install -g @hey-echodev/cli@latest
+```
+
+That said, two of the changes above benefit from a hook-recipe refresh —
+one is **required** *if* you use `recall --if-expired-block`, the other is
+recommended for everyone.
+
+#### Required if you use `recall --if-expired-block`
+
+`--if-expired-block` previously read the pending edit's content from
+`CLAUDE_TOOL_INPUT_*` env vars. Those reads have been removed (#10); the
+feature now consumes the same documented stdin-JSON contract `recall
+--from-stdin` reads. **If your `.claude/settings.json` still has the old
+env-var-based recipe, `--if-expired-block` will silently no-op.** Refresh
+the recipe (see below).
+
+If you don't use `--if-expired-block` (it's off by default), you can skip
+this concern.
+
+#### Recommended for everyone: refresh the hook recipe
+
+Two improvements wait behind a fresh recipe regardless of
+`--if-expired-block`:
+
+- **`command -v echodev` guard** (#2) — silences `echodev: command not
+  found` stderr on teammates' machines without the CLI installed.
+- **`--from-stdin` flag** (#4) — switches the contract from an
+  undocumented Claude Code internal env var (`$CLAUDE_TOOL_INPUT_file_path`)
+  to the documented stdin-JSON contract. More stable across Claude Code
+  releases; also tested against Claude Code as of 2026-04 (see README).
+
+Old hooks keep working as long as Claude Code still emits the env var, so
+this isn't an emergency — it's forward-proofing.
+
+#### How to refresh
+
+```bash
+cd /path/to/your-project
+echodev init
+```
+
+`init` prints the new recipe to stdout. Open `.claude/settings.json` and
+replace your existing EchoDev `PreToolUse` and `Stop` hook entries with
+the printed JSON. Then restart Claude Code or run `/hooks` inside it to
+reload.
+
+If `init` says `Hooks already installed in .claude/settings.json —
+skipping recipe.` you're already on a recipe that contains
+`echodev recall`; check whether it's the new `--from-stdin` form. If not,
+edit by hand or delete the EchoDev entries and re-run `init`.
+
+#### No action needed for these
+
+- **Decision data** — `schema_version` machinery shipped in 0.2.0; existing
+  decisions are already at `"1.0"`. If you upgraded from a pre-0.2.0
+  version, run `echodev migrate` once (idempotent).
+- **Bridge artifacts** — if `.echodev/bridge/` has accumulated old
+  `*.request.json` / `*.response.txt` files, the next successful
+  skill-bridge extract trims it to the newest 10 stamps automatically (#3).
+
+### Closed in this release
+
+- **Reported issues**: #1, #2, #3, #4, #5
+- **Follow-up issues**: #10, #11, #12, #13, #18
+- **PRs**: #6, #7, #8, #9, #14, #15, #16, #17, #19
+
 ## [0.2.0] - 2026-04-22
 
 User-feedback-driven bug-fix and UX batch. Reported by an admin after first

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hey-echodev/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "EchoDev — persistent design memory for Claude-assisted codebases",
   "license": "MIT",
   "homepage": "https://github.com/jieyao-MilestoneHub/EchoDev",


### PR DESCRIPTION
## Summary

Release PR for `@hey-echodev/cli@0.3.0`. Bumps the CLI version from `0.2.0` → `0.3.0` and adds a CHANGELOG entry.

## SemVer reasoning

**Minor bump.** No breaking changes to the documented CLI surface:

- New flags / additive behavior: `recall --from-stdin` (#4), bridge auto-prune (#3), forward-migration chain (#5/#12)
- Bug fixes: `command -v` guard (#2), args parser greedy bug (#11)
- Behavioral changes that are *not* documented contract changes: `init` now prints the hook recipe instead of writing a sidecar (#1) — old recipe keeps working in users' `settings.json`; the dropped `$CLAUDE_TOOL_INPUT_*` env vars (#4, #10) were never documented public contracts.

A patch bump (0.2.1) understates the user-facing surface gain. A major bump (1.0.0) overstates it — the project is still pre-1.0 and these aren't breaking changes to documented behavior.

## What's in the box

| Issue | PR | Description |
|---|---|---|
| #1 | #6 | Drop `.claude/echodev.hooks.snippet.json` sidecar; print recipe inline |
| #2 | #7 | Hook recipe gains `command -v echodev` guard |
| #3 | #8 | Bridge artifacts auto-prune after each successful skill call |
| #4 | #9 | Hook contract switched to documented stdin-JSON; `recall --from-stdin` flag |
| #5 / #12 | #16 | Migrate refactored to forward-migration chain; README "Schema versioning" section |
| #10 | #15 | `--if-expired-block` no longer reads undocumented env vars |
| #11 | #14 | `args` parser fix — boolean flags don't consume next positional |
| #13 | #17 | Vitest + 42 regression tests |
| #18 | #19 | `docs/best_practice.md` — user-facing best-practices guide |

## Best-practice anchors driving this batch

Every change in the batch was justified against two anchors (see `docs/best_practice.md` for the consolidated reasoning):

- [Claude Code best practices](https://code.claude.com/docs/en/best-practices) — *"Edit `.claude/settings.json` directly"* (#1), *"Address root causes, not symptoms"* (#2, #4, #10), *"Hooks are deterministic"* (#3 prune lives where files are created)
- EchoDev README thesis #3 *"Prefer silence over noise"* — applied to: `command -v` guard suppressing stderr (#2), bridge prune being best-effort (#3), `recall --from-stdin` no-op on missing/invalid input (#4), schema_version fail-closed reads (#5/#12)

## Verification

- [x] `npm test` — 42 tests pass on this branch
- [x] `npm run build` — builds clean; no test files in `dist/`
- [x] `node packages/cli/dist/index.js init` in a fresh repo — recipe stdout matches `docs/best_practice.md` §2
- [x] CHANGELOG entry follows the v0.2.0 structure (Fixed P0 / Added / Internal sections)
- [x] `packages/cli/package.json` version `"0.3.0"` — will be checked against the release tag `v0.3.0` by `.github/workflows/publish.yml`

## After this PR merges

1. Pull main, tag locally: `git tag v0.3.0`
2. (Optional) Run a publish dry-run: `gh workflow run publish.yml --field dry-run=true`
3. Push tag to trigger real publish: `git push origin v0.3.0`

The publish workflow (`on: push: tags: ['v*.*.*']`) handles the rest via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)