### PR TITLE
fix(ci): pin npm to 11.5.1 instead of @latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,14 @@ jobs:
       # npm >= 11.5.1. Node 22 LTS ships with npm 10.x, so we upgrade
       # explicitly. Without this the publish step 404s even when OIDC
       # provenance signing succeeds.
-      - run: npm install -g npm@latest
+      #
+      # Pinned (not `@latest`): on 2026-04-26 the v0.3.0 publish dry-run
+      # failed because npm 10.x self-upgrading to npm@latest (12.x) left a
+      # half-rewritten global node_modules and threw
+      # `Cannot find module 'promise-retry'` from @npmcli/arborist. 11.5.1
+      # is the documented OIDC minimum and a known-good landing point.
+      # Bump deliberately when there's a reason; do not float to @latest.
+      - run: npm install -g npm@11.5.1
       - run: node --version && npm --version
 
       - run: npm ci


### PR DESCRIPTION
## Summary

Blocks the v0.3.0 release ([dry-run run #24959620966](https://github.com/jieyao-MilestoneHub/EchoDev/actions/runs/24959620966) failed; see "Failure analysis" below).

`.github/workflows/publish.yml` ran `npm install -g npm@latest` to satisfy the OIDC trusted-publishing minimum (`npm >= 11.5.1`). That step now fails on the GitHub Actions runner because the bundled npm 10.x can't cleanly self-upgrade to npm@latest (currently in the 12.x line) — the partial in-place rewrite leaves a corrupted global node_modules.

Pinning to **11.5.1** (the documented OIDC minimum, also referenced in the workflow's own surrounding comment) sidesteps the floating-version issue.

## Failure analysis

From the dry-run logs:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
```

This is the classic signature of an interrupted/inconsistent npm self-upgrade — `@npmcli/arborist` (npm's reify engine) is trying to load a peer dep that the half-finished install didn't lay down yet. It's not a transient network issue; re-running without changing the install target produces the same failure.

## Why pin (and not just bump)

- The workflow comment already states the minimum: `npm >= 11.5.1`. Pinning matches the contract.
- `@latest` floats — every Actions run becomes a function of "what's npm's latest *right now*". That's how we got here in the first place.
- Bumping should be a deliberate decision tied to a feature need, not a side effect of CI re-running on a Tuesday.

The commit message and updated comment in `publish.yml` document this rationale so a future maintainer doesn't re-introduce `@latest`.

## After this merges

Re-trigger the v0.3.0 dry-run (`gh workflow run publish.yml --field dry-run=true`); it should now reach the `npm publish --dry-run` step. Once that's green, push `v0.3.0` tag to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)